### PR TITLE
Use long long for till_next_keep_alive

### DIFF
--- a/src/mqtt_wss_client.c
+++ b/src/mqtt_wss_client.c
@@ -1079,7 +1079,7 @@ int mqtt_wss_service(mqtt_wss_client client, int timeout_ms)
     long long int till_next_keep_alive = t_till_next_keepalive_ms(client);
     if (client->mqtt_connected && (timeout_ms < 0 || timeout_ms >= till_next_keep_alive)) {
         #ifdef DEBUG_ULTRA_VERBOSE
-            mws_debug(client->log, "Shortening Timeout requested %d to %ld to ensure keep-alive can be sent", timeout_ms, till_next_keep_alive);
+            mws_debug(client->log, "Shortening Timeout requested %d to %lld to ensure keep-alive can be sent", timeout_ms, till_next_keep_alive);
         #endif
         timeout_ms = till_next_keep_alive;
         send_keepalive = 1;

--- a/src/mqtt_wss_client.c
+++ b/src/mqtt_wss_client.c
@@ -1052,10 +1052,10 @@ static int handle_mqtt(mqtt_wss_client client)
 }
 
 #define SEC_TO_MSEC 1000
-static inline long int t_till_next_keepalive_ms(mqtt_wss_client client)
+static inline long long int t_till_next_keepalive_ms(mqtt_wss_client client)
 {
     time_t last_send = client->internal_mqtt ? mqtt_ng_last_send_time(client->mqtt.mqtt_ctx) : client->mqtt.mqtt_c->mqtt_client->time_of_last_send;
-    long int next_mqtt_keep_alive = (last_send * SEC_TO_MSEC)
+    long long int next_mqtt_keep_alive = (last_send * SEC_TO_MSEC)
         + (client->mqtt_keepalive * (SEC_TO_MSEC * 0.75 /* SEND IN ADVANCE */));
     return(next_mqtt_keep_alive - (MQTT_PAL_TIME() * SEC_TO_MSEC));
 }
@@ -1076,10 +1076,10 @@ int mqtt_wss_service(mqtt_wss_client client, int timeout_ms)
 #endif
 
     // Check user requested TO doesn't interfere with MQTT keep alives
-    long int till_next_keep_alive = t_till_next_keepalive_ms(client);
+    long long int till_next_keep_alive = t_till_next_keepalive_ms(client);
     if (client->mqtt_connected && (timeout_ms < 0 || timeout_ms >= till_next_keep_alive)) {
         #ifdef DEBUG_ULTRA_VERBOSE
-            mws_debug(client->log, "Shortening Timeout requested %d to %d to ensure keep-alive can be sent", timeout_ms, till_next_keep_alive);
+            mws_debug(client->log, "Shortening Timeout requested %d to %ld to ensure keep-alive can be sent", timeout_ms, till_next_keep_alive);
         #endif
         timeout_ms = till_next_keep_alive;
         send_keepalive = 1;


### PR DESCRIPTION
Use long long for till_next_keep_alive.

This seems to fix the case for not sending keep-alives under musl/arm/32bit.

The end result of `t_till_next_keepalive_ms` should be small enough to fit in `timeout_ms`. Not sure if it needs more space as well ?

It was tested by building an armv7l static build and running on Raspbian 32bit.

Before this change, values of `next_mqtt_keep_alive` would be `2147483647` resulting after the function `t_till_next_keepalive_ms` ended to `-679920801`.

With this change, values appear to be calculated ok, and running the agent overnight did not show a single disconnect.

![image](https://user-images.githubusercontent.com/1905463/194237853-cca4598f-71a2-429f-beb1-945785ce7054.png)

(Patch was installed at about 18:00:00 yesterday, disconnects appeared this morning after the agent auto-updated).