### PR TITLE
Add support wolfssl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@
 
 CC = gcc -std=gnu99
 CFLAGS = -Wextra -Wall `pkg-config --cflags openssl` `pkg-config --cflags libcrypto`
+LDFLAGS = `pkg-config --libs openssl`
 BUILD_DIR = build
 
 INCLUDES = -Isrc/include -Ic-rbuf/include -Ic_rhash/include -Imqtt/include
@@ -47,7 +48,7 @@ libmqttwebsockets.a: $(BUILD_DIR)/mqtt_wss_client.o $(BUILD_DIR)/ws_client.o c-r
 	ar rcs libmqttwebsockets.a $(BUILD_DIR)/mqtt_wss_client.o $(BUILD_DIR)/ws_client.o c-rbuf/build/ringbuffer.o $(BUILD_DIR)/c_rhash.o $(BUILD_DIR)/mqtt_wss_log.o $(BUILD_DIR)/mqtt_ng.o $(BUILD_DIR)/common_public.o
 
 test: $(BUILD_DIR)/test.o libmqttwebsockets.a
-	$(CC) -o test $(BUILD_DIR)/test.o libmqttwebsockets.a `pkg-config --libs openssl` -lpthread $(CFLAGS)
+	$(CC) -o test $(BUILD_DIR)/test.o libmqttwebsockets.a $(LDFLAGS) -lpthread $(CFLAGS)
 
 clean:
 	rm -f $(BUILD_DIR)/*

--- a/src/include/mqtt_ssl.h
+++ b/src/include/mqtt_ssl.h
@@ -4,6 +4,11 @@
 #if defined(ENABLE_HTTPS_WITH_OPENSSL)
 #include <openssl/err.h>
 #include <openssl/ssl.h>
+
+#if defined(OPENSSL_VERSION_NUMBER) && (OPENSSL_VERSION_NUMBER < OPENSSL_VERSION_110) && (SSLEAY_VERSION_NUMBER >= OPENSSL_VERSION_097)
+#include <openssl/conf.h>
+#endif
+
 #elif defined(ENABLE_HTTPS_WITH_WOLFSSL)
 #include <wolfssl/version.h>
 #include <wolfssl/options.h>

--- a/src/include/mqtt_ssl.h
+++ b/src/include/mqtt_ssl.h
@@ -1,0 +1,19 @@
+#ifndef MQTT_WEBSOCKET_SSL_H_
+# define MQTT_WEBSOCKET_SSL_H_ 1
+
+#if defined(ENABLE_HTTPS_WITH_OPENSSL)
+#include <openssl/err.h>
+#include <openssl/ssl.h>
+#elif defined(ENABLE_HTTPS_WITH_WOLFSSL)
+#include <wolfssl/version.h>
+#include <wolfssl/options.h>
+#include <wolfssl/ssl.h>
+#include <wolfssl/openssl/ssl.h>
+#include <wolfssl/ssl.h>
+#include <wolfssl/error-ssl.h>
+
+#include <wolfssl/openssl/sha.h>
+#include <wolfssl/openssl/evp.h>
+#endif
+
+#endif

--- a/src/include/mqtt_wss_client.h
+++ b/src/include/mqtt_wss_client.h
@@ -165,11 +165,7 @@ struct mqtt_wss_stats {
 struct mqtt_wss_stats mqtt_wss_get_stats(mqtt_wss_client client);
 
 #ifdef MQTT_WSS_DEBUG
-#if defined(ENABLE_HTTPS_WITH_OPENSSL)
-#include <openssl/ssl.h>
-#elif defined(ENABLE_HTTPS_WITH_WOLFSSL)
-#include <wolfssl/openssl/ssl.h>
-#endif
+#include "mqtt_ssl.h"
 void mqtt_wss_set_SSL_CTX_keylog_cb(mqtt_wss_client client, void (*ssl_ctx_keylog_cb)(const SSL *ssl, const char *line));
 #endif
 

--- a/src/include/mqtt_wss_client.h
+++ b/src/include/mqtt_wss_client.h
@@ -167,6 +167,8 @@ struct mqtt_wss_stats mqtt_wss_get_stats(mqtt_wss_client client);
 #ifdef MQTT_WSS_DEBUG
 #ifndef NETDATA_USE_WOLFSSL
 #include <openssl/ssl.h>
+#elif defined(NETDATA_USE_WOLFSSL)
+#include <wolfssl/openssl/ssl.h>
 #endif
 void mqtt_wss_set_SSL_CTX_keylog_cb(mqtt_wss_client client, void (*ssl_ctx_keylog_cb)(const SSL *ssl, const char *line));
 #endif

--- a/src/include/mqtt_wss_client.h
+++ b/src/include/mqtt_wss_client.h
@@ -165,7 +165,9 @@ struct mqtt_wss_stats {
 struct mqtt_wss_stats mqtt_wss_get_stats(mqtt_wss_client client);
 
 #ifdef MQTT_WSS_DEBUG
+#ifndef NETDATA_USE_WOLFSSL
 #include <openssl/ssl.h>
+#endif
 void mqtt_wss_set_SSL_CTX_keylog_cb(mqtt_wss_client client, void (*ssl_ctx_keylog_cb)(const SSL *ssl, const char *line));
 #endif
 

--- a/src/include/mqtt_wss_client.h
+++ b/src/include/mqtt_wss_client.h
@@ -165,9 +165,9 @@ struct mqtt_wss_stats {
 struct mqtt_wss_stats mqtt_wss_get_stats(mqtt_wss_client client);
 
 #ifdef MQTT_WSS_DEBUG
-#ifndef NETDATA_USE_WOLFSSL
+#if defined(ENABLE_HTTPS_WITH_OPENSSL)
 #include <openssl/ssl.h>
-#elif defined(NETDATA_USE_WOLFSSL)
+#elif defined(ENABLE_HTTPS_WITH_WOLFSSL)
 #include <wolfssl/openssl/ssl.h>
 #endif
 void mqtt_wss_set_SSL_CTX_keylog_cb(mqtt_wss_client client, void (*ssl_ctx_keylog_cb)(const SSL *ssl, const char *line));

--- a/src/mqtt_wss_client.c
+++ b/src/mqtt_wss_client.c
@@ -30,10 +30,10 @@
 #include <netinet/tcp.h> //TCP_NODELAY
 #include <netdb.h>
 
-#ifndef NETDATA_USE_WOLFSSL
+#if defined(ENABLE_HTTPS_WITH_OPENSSL)
 #include <openssl/err.h>
 #include <openssl/ssl.h>
-#elif defined(NETDATA_USE_WOLFSSL)
+#elif defined(ENABLE_HTTPS_WITH_WOLFSSL)
 #include <wolfssl/options.h>
 #include <wolfssl/ssl.h>
 #include <wolfssl/openssl/err.h>
@@ -628,7 +628,7 @@ int mqtt_wss_connect(mqtt_wss_client client, char *host, int port, struct mqtt_c
         if (http_proxy_connect(client))
             return -4;
 
-#ifndef NETDATA_USE_WOLFSSL
+#if defined(ENABLE_HTTPS_WITH_OPENSSL)
 #if OPENSSL_VERSION_NUMBER < OPENSSL_VERSION_110
 #if (SSLEAY_VERSION_NUMBER >= OPENSSL_VERSION_097)
     OPENSSL_config(NULL);
@@ -641,12 +641,12 @@ int mqtt_wss_connect(mqtt_wss_client client, char *host, int port, struct mqtt_c
         return -1;
     };
 #endif //OPENSSL_VERSION_NUMBER < OPENSSL_VERSION_110
-#else
+#elif defined(ENABLE_HTTPS_WITH_WOLFSSL)
     if (wolfSSL_Init() != SSL_SUCCESS) {
         mws_error(client->log, "Failed to initialize SSL");
         return -1;
     }
-#endif // NETDATA_USE_WOLFSSL
+#endif // ENABLE_HTTPS_WITH_WOLFSSL
 
     // free SSL structs from possible previous connections
     if (client->ssl)

--- a/src/mqtt_wss_client.c
+++ b/src/mqtt_wss_client.c
@@ -30,24 +30,12 @@
 #include <netinet/tcp.h> //TCP_NODELAY
 #include <netdb.h>
 
-#if defined(ENABLE_HTTPS_WITH_OPENSSL)
-#include <openssl/err.h>
-#include <openssl/ssl.h>
-#elif defined(ENABLE_HTTPS_WITH_WOLFSSL)
-#include <wolfssl/options.h>
-#include <wolfssl/ssl.h>
-#include <wolfssl/openssl/err.h>
-#include <wolfssl/openssl/ssl.h>
-#endif
+#include "mqtt_ssl.h"
 
 #define PIPE_READ_END  0
 #define PIPE_WRITE_END 1
 #define POLLFD_SOCKET  0
 #define POLLFD_PIPE    1
-
-#if defined(OPENSSL_VERSION_NUMBER) && (OPENSSL_VERSION_NUMBER < OPENSSL_VERSION_110) && (SSLEAY_VERSION_NUMBER >= OPENSSL_VERSION_097)
-#include <openssl/conf.h>
-#endif
 
 //TODO MQTT_PUBLISH_RETAIN should not be needed anymore
 #define MQTT_PUBLISH_RETAIN 0x01

--- a/src/mqtt_wss_client.c
+++ b/src/mqtt_wss_client.c
@@ -30,15 +30,17 @@
 #include <netinet/tcp.h> //TCP_NODELAY
 #include <netdb.h>
 
+#ifndef NETDATA_USE_WOLFSSL
 #include <openssl/err.h>
 #include <openssl/ssl.h>
+#endif
 
 #define PIPE_READ_END  0
 #define PIPE_WRITE_END 1
 #define POLLFD_SOCKET  0
 #define POLLFD_PIPE    1
 
-#if (OPENSSL_VERSION_NUMBER < OPENSSL_VERSION_110) && (SSLEAY_VERSION_NUMBER >= OPENSSL_VERSION_097)
+#if defined(OPENSSL_VERSION_NUMBER) && (OPENSSL_VERSION_NUMBER < OPENSSL_VERSION_110) && (SSLEAY_VERSION_NUMBER >= OPENSSL_VERSION_097)
 #include <openssl/conf.h>
 #endif
 

--- a/src/mqtt_wss_client.c
+++ b/src/mqtt_wss_client.c
@@ -33,6 +33,9 @@
 #ifndef NETDATA_USE_WOLFSSL
 #include <openssl/err.h>
 #include <openssl/ssl.h>
+#elif defined(NETDATA_USE_WOLFSSL)
+#include <wolfssl/openssl/err.h>
+#include <wolfssl/openssl/ssl.h>
 #endif
 
 #define PIPE_READ_END  0

--- a/src/ws_client.c
+++ b/src/ws_client.c
@@ -19,6 +19,8 @@
 
 #ifndef NETDATA_USE_WOLFSSL
 #include <openssl/evp.h>
+#elif defined(NETDATA_USE_WOLFSSL)
+#include <wolfssl/openssl/evp.h>
 #endif
 
 #include "ws_client.h"

--- a/src/ws_client.c
+++ b/src/ws_client.c
@@ -17,7 +17,9 @@
 #include <errno.h>
 #include <ctype.h>
 
+#ifndef NETDATA_USE_WOLFSSL
 #include <openssl/evp.h>
+#endif
 
 #include "ws_client.h"
 #include "common_internal.h"

--- a/src/ws_client.c
+++ b/src/ws_client.c
@@ -17,9 +17,9 @@
 #include <errno.h>
 #include <ctype.h>
 
-#ifndef NETDATA_USE_WOLFSSL
+#if defined(ENABLE_HTTPS_WITH_OPENSSL)
 #include <openssl/evp.h>
-#elif defined(NETDATA_USE_WOLFSSL)
+#elif defined(ENABLE_HTTPS_WITH_WOLFSSL)
 #include <wolfssl/options.h>
 #include <wolfssl/openssl/evp.h>
 #endif

--- a/src/ws_client.c
+++ b/src/ws_client.c
@@ -17,12 +17,7 @@
 #include <errno.h>
 #include <ctype.h>
 
-#if defined(ENABLE_HTTPS_WITH_OPENSSL)
-#include <openssl/evp.h>
-#elif defined(ENABLE_HTTPS_WITH_WOLFSSL)
-#include <wolfssl/options.h>
-#include <wolfssl/openssl/evp.h>
-#endif
+#include "mqtt_ssl.h"
 
 #include "ws_client.h"
 #include "common_internal.h"

--- a/src/ws_client.c
+++ b/src/ws_client.c
@@ -20,6 +20,7 @@
 #ifndef NETDATA_USE_WOLFSSL
 #include <openssl/evp.h>
 #elif defined(NETDATA_USE_WOLFSSL)
+#include <wolfssl/options.h>
 #include <wolfssl/openssl/evp.h>
 #endif
 


### PR DESCRIPTION
This is the first PR bringing support for `WolfSSL` library. By default the library does not enable everything we need, so I had to compile library with the following steps and options:

```sh
# ./autogen.sh
# CFLAGS="-DOPENSSL_EXTRA -DHAVE_SECRET_CALLBACK -DWOLFSSL_TRUST_PEER_CERT" ./configure --prefix=/usr --enable-all --enable-static --enable-iopool --enable-secure-renegotiation --enable-sni
# make  CFLAGS="-DOPENSSL_EXTRA -DHAVE_SECRET_CALLBACK -DWOLFSSL_TRUST_PEER_CERT"
# make install
# ldconfig
```

After this I used this branch with PR https://github.com/netdata/netdata/pull/14808 and I ran tests with `streaming`, `dashboard` and `cloud`.